### PR TITLE
Tidy up the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-.gitignore
 /.DS_Store
-/Games/Assets/__pycache__/*
-/Games/__pycache__/*
+__pycache__


### PR DESCRIPTION
The .gitignore file should not ignore itself.

Git matches patterns. Each line in a .gitignore file is a pattern. If the pattern does not have a directory separator at the beginning or middle (or both), then the pattern will match at any level below the .gitignore file.

See: https://git-scm.com/docs/gitignore#_pattern_format